### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -8,6 +8,9 @@ on:
       - reopened
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/samulopez/WhisperBox/security/code-scanning/2](https://github.com/samulopez/WhisperBox/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is minimally scoped.  
Best fix here: define workflow-level permissions directly under `on` (or under `name`) with `contents: read`, since all shown jobs are read-only CI tasks (checkout, install, lint, typecheck). This avoids changing functionality while satisfying least privilege and the CodeQL rule.

Change needed in:

- **File:** `.github/workflows/pr-check.yml`
- **Region:** after the `on:` trigger section and before `jobs:`
- **Edit:** insert:
  ```yaml
  permissions:
    contents: read
  ```

No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
