### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/samulopez/WhisperBox/security/code-scanning/1](https://github.com/samulopez/WhisperBox/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root in `.github/workflows/release.yml` so all jobs inherit it.

Best fix here (without changing behavior): define:
- `contents: write` (required for creating/updating GitHub releases and uploading release assets)
- avoid unnecessary additional scopes unless proven needed

This should be inserted after the `on:` trigger section and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
